### PR TITLE
errors: check for err before attempting to parse the response

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -85,7 +85,10 @@ func (c *Client) newRequest(ctx context.Context, method, apiEndpoint string, pay
 }
 
 func (c *Client) call(request *http.Request, structure interface{}) (result *ResponseScheme, err error) {
-	response, _ := c.HTTP.Do(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return nil, err
+	}
 	return transformTheHTTPResponse(response, structure)
 }
 

--- a/confluence/confluence.go
+++ b/confluence/confluence.go
@@ -101,7 +101,10 @@ func (c *Client) newRequest(ctx context.Context, method, apiEndpoint string, pay
 }
 
 func (c *Client) Call(request *http.Request, structure interface{}) (result *ResponseScheme, err error) {
-	response, _ := c.HTTP.Do(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return nil, err
+	}
 	return transformTheHTTPResponse(response, structure)
 }
 

--- a/jira/agile/agile.go
+++ b/jira/agile/agile.go
@@ -75,7 +75,10 @@ func (c *Client) newRequest(ctx context.Context, method, apiEndpoint string, pay
 }
 
 func (c *Client) Call(request *http.Request, structure interface{}) (result *ResponseScheme, err error) {
-	response, _ := c.HTTP.Do(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return nil, err
+	}
 	return transformTheHTTPResponse(response, structure)
 }
 

--- a/jira/sm/sm.go
+++ b/jira/sm/sm.go
@@ -99,7 +99,10 @@ func (c *Client) newRequest(ctx context.Context, method, apiEndpoint string, pay
 }
 
 func (c *Client) Call(request *http.Request, structure interface{}) (result *ResponseScheme, err error) {
-	response, _ := c.HTTP.Do(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return nil, err
+	}
 	return transformTheHTTPResponse(response, structure)
 }
 

--- a/jira/v2/jira.go
+++ b/jira/v2/jira.go
@@ -189,7 +189,10 @@ func (c *Client) newRequest(ctx context.Context, method, apiEndpoint string, pay
 }
 
 func (c *Client) call(request *http.Request, structure interface{}) (result *ResponseScheme, err error) {
-	response, _ := c.HTTP.Do(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return nil, err
+	}
 	return transformTheHTTPResponse(response, structure)
 }
 

--- a/jira/v3/jira.go
+++ b/jira/v3/jira.go
@@ -192,7 +192,10 @@ func (c *Client) newRequest(ctx context.Context, method, apiEndpoint string, pay
 }
 
 func (c *Client) call(request *http.Request, structure interface{}) (result *ResponseScheme, err error) {
-	response, _ := c.HTTP.Do(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return nil, err
+	}
 	return transformTheHTTPResponse(response, structure)
 }
 


### PR DESCRIPTION
* this will then give us the correct error, which is likely "context cancelled"
* we wanted to do this before, and are doing it now that we've forked the repo