### PR TITLE
Add an empty field method for helpful clearing of values

### DIFF
--- a/pkg/infra/models/jira_customFields.go
+++ b/pkg/infra/models/jira_customFields.go
@@ -7,6 +7,22 @@ import (
 
 type CustomFields struct{ Fields []map[string]interface{} }
 
+// In order to clear a field create an empty field which will wipe the value
+func (c *CustomFields) EmptyField(customFieldID string) (err error) {
+	if len(customFieldID) == 0 {
+		return fmt.Errorf("error, please provide a valid customFieldID value")
+	}
+
+	var fieldNode = map[string]interface{}{}
+	fieldNode[customFieldID] = nil
+
+	var fieldsNode = map[string]interface{}{}
+	fieldsNode["fields"] = fieldNode
+
+	c.Fields = append(c.Fields, fieldsNode)
+	return nil
+}
+
 func (c *CustomFields) Groups(customFieldID string, groups []string) (err error) {
 
 	if len(customFieldID) == 0 {


### PR DESCRIPTION
This is how you are meant to set a field to empty in the Jira API.

None of the other constructors allow you to set empty values - so we can use this now instead (until we maybe unfork ourselves).