### PR TITLE
Add Confluence v2 Folder.Descendants service

### DIFF
--- a/confluence/internal/folder_impl.go
+++ b/confluence/internal/folder_impl.go
@@ -1,0 +1,73 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/confluence"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// NewFolderService returns a new Confluence V2 Folder service
+func NewFolderService(client service.Connector) *FolderService {
+	return &FolderService{internalClient: &internalFolderImpl{c: client}}
+}
+
+type FolderService struct {
+	internalClient confluence.FolderConnector
+}
+
+// Descendants returns all descendants of a folder, at any depth.
+//
+// Descendants are mixed content types (page, folder, whiteboard, database, embed).
+//
+// The number of results is limited by the limit parameter and additional results (if available)
+//
+// will be available through the next cursor. A depth of 0 returns all levels.
+//
+// GET /wiki/api/v2/folders/{id}/descendants
+//
+// https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-descendants/#api-folders-id-descendants-get
+func (f *FolderService) Descendants(ctx context.Context, folderID int, depth int, cursor string, limit int) (*model.FolderDescendantChunkScheme, *model.ResponseScheme, error) {
+	return f.internalClient.Descendants(ctx, folderID, depth, cursor, limit)
+}
+
+type internalFolderImpl struct {
+	c service.Connector
+}
+
+func (i *internalFolderImpl) Descendants(ctx context.Context, folderID int, depth int, cursor string, limit int) (*model.FolderDescendantChunkScheme, *model.ResponseScheme, error) {
+
+	if folderID == 0 {
+		return nil, nil, model.ErrNoFolderIDError
+	}
+
+	query := url.Values{}
+	query.Add("limit", strconv.Itoa(limit))
+
+	if cursor != "" {
+		query.Add("cursor", cursor)
+	}
+
+	if depth != 0 {
+		query.Add("depth", strconv.Itoa(depth))
+	}
+
+	endpoint := fmt.Sprintf("wiki/api/v2/folders/%v/descendants?%v", folderID, query.Encode())
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chunk := new(model.FolderDescendantChunkScheme)
+	response, err := i.c.Call(request, chunk)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return chunk, response, nil
+}

--- a/confluence/internal/folder_impl_test.go
+++ b/confluence/internal/folder_impl_test.go
@@ -1,0 +1,191 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_internalFolderImpl_Descendants(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx      context.Context
+		folderID int
+		depth    int
+		cursor   string
+		limit    int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:      context.Background(),
+				folderID: 20001,
+				depth:    10,
+				cursor:   "cursor-sample",
+				limit:    200,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"wiki/api/v2/folders/20001/descendants?cursor=cursor-sample&depth=10&limit=200",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.FolderDescendantChunkScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the depth is not provided it is omitted",
+			args: args{
+				ctx:      context.Background(),
+				folderID: 20001,
+				cursor:   "cursor-sample",
+				limit:    200,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"wiki/api/v2/folders/20001/descendants?cursor=cursor-sample&limit=200",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.FolderDescendantChunkScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the folder id is not provided",
+			args: args{
+				ctx: context.Background(),
+			},
+			wantErr: true,
+			Err:     model.ErrNoFolderIDError,
+		},
+
+		{
+			name: "when the http request cannot be created",
+			args: args{
+				ctx:      context.Background(),
+				folderID: 20001,
+				depth:    10,
+				cursor:   "cursor-sample",
+				limit:    200,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"wiki/api/v2/folders/20001/descendants?cursor=cursor-sample&depth=10&limit=200",
+					"", nil).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+
+		{
+			name: "when the call fails",
+			args: args{
+				ctx:      context.Background(),
+				folderID: 20001,
+				depth:    10,
+				cursor:   "cursor-sample",
+				limit:    200,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"wiki/api/v2/folders/20001/descendants?cursor=cursor-sample&depth=10&limit=200",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.FolderDescendantChunkScheme{}).
+					Return(&model.ResponseScheme{}, errors.New("error, request failed"))
+
+				fields.c = client
+			},
+
+			wantErr: true,
+			Err:     errors.New("error, request failed"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			newService := NewFolderService(testCase.fields.c)
+
+			gotResult, gotResponse, err := newService.Descendants(testCase.args.ctx, testCase.args.folderID,
+				testCase.args.depth, testCase.args.cursor, testCase.args.limit)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+
+		})
+	}
+}

--- a/confluence/v2/api_client_impl.go
+++ b/confluence/v2/api_client_impl.go
@@ -40,6 +40,7 @@ func New(httpClient common.HttpClient, site string) (*Client, error) {
 
 	client.Auth = internal.NewAuthenticationService(client)
 	client.Page = internal.NewPageService(client)
+	client.Folder = internal.NewFolderService(client)
 	client.Space = internal.NewSpaceV2Service(client)
 	client.Attachment = internal.NewAttachmentService(client, internal.NewAttachmentVersionService(client))
 	client.CustomContent = internal.NewCustomContentService(client)
@@ -52,6 +53,7 @@ type Client struct {
 	Site          *url.URL
 	Auth          common.Authentication
 	Page          *internal.PageService
+	Folder        *internal.FolderService
 	Space         *internal.SpaceV2Service
 	Attachment    *internal.AttachmentService
 	CustomContent *internal.CustomContentService

--- a/pkg/infra/models/confluence_folder.go
+++ b/pkg/infra/models/confluence_folder.go
@@ -1,0 +1,26 @@
+package models
+
+// FolderDescendantChunkScheme represents a chunk of folder descendants in Confluence.
+type FolderDescendantChunkScheme struct {
+	Results []*FolderDescendantScheme         `json:"results,omitempty"` // The descendants in the chunk.
+	Links   *FolderDescendantChunkLinksScheme `json:"_links,omitempty"`  // The links of the chunk.
+}
+
+// FolderDescendantChunkLinksScheme represents the links of a chunk of folder descendants in Confluence.
+type FolderDescendantChunkLinksScheme struct {
+	Next string `json:"next,omitempty"` // The link to the next chunk of descendants.
+}
+
+// FolderDescendantScheme represents a descendant of a folder in Confluence.
+//
+// Descendants are mixed content types (page, folder, whiteboard, database, embed).
+type FolderDescendantScheme struct {
+	ID            string `json:"id,omitempty"`            // The ID of the descendant.
+	Type          string `json:"type,omitempty"`          // The content type (page, folder, whiteboard, database, embed).
+	Status        string `json:"status,omitempty"`        // The status of the descendant.
+	Title         string `json:"title,omitempty"`         // The title of the descendant.
+	ParentID      string `json:"parentId,omitempty"`      // The ID of the parent of the descendant.
+	ParentType    string `json:"parentType,omitempty"`    // The content type of the parent.
+	Depth         int    `json:"depth,omitempty"`         // The depth of the descendant relative to the folder.
+	ChildPosition int    `json:"childPosition,omitempty"` // The position of the descendant amongst its siblings.
+}

--- a/pkg/infra/models/errors.go
+++ b/pkg/infra/models/errors.go
@@ -39,6 +39,7 @@ var (
 	ErrNoCustomContentTypeError            = errors.New("confluence: no custom content type set")
 	ErrNoCustomContentIDError              = errors.New("confluence: no custom content id set")
 	ErrNoPageIDError                       = errors.New("confluence: no page id set")
+	ErrNoFolderIDError                     = errors.New("confluence: no folder id set")
 	ErrNoSpaceIDError                      = errors.New("confluence: no space id set")
 	ErrNoTargetIDError                     = errors.New("confluence: no target id set")
 	ErrNoPositionError                     = errors.New("confluence: no position set")

--- a/service/confluence/folder.go
+++ b/service/confluence/folder.go
@@ -1,0 +1,24 @@
+package confluence
+
+import (
+	"context"
+	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+)
+
+// FolderConnector represents the Confluence Cloud Folders.
+// Use it to navigate the contents of a folder.
+type FolderConnector interface {
+
+	// Descendants returns all descendants of a folder, at any depth.
+	//
+	// Descendants are mixed content types (page, folder, whiteboard, database, embed).
+	//
+	// The number of results is limited by the limit parameter and additional results (if available)
+	//
+	// will be available through the next cursor. A depth of 0 returns all levels.
+	//
+	// GET /wiki/api/v2/folders/{id}/descendants
+	//
+	// https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-descendants/#api-folders-id-descendants-get
+	Descendants(ctx context.Context, folderID int, depth int, cursor string, limit int) (*models.FolderDescendantChunkScheme, *models.ResponseScheme, error)
+}


### PR DESCRIPTION
## What

Adds a v2 **Folder** service to the Confluence client, exposing:

```
GET /wiki/api/v2/folders/{id}/descendants
```

`Folder.Descendants(ctx, folderID, depth, cursor, limit)` returns all descendants of a folder — pages, sub-folders, whiteboards, databases, embeds — at any depth, with cursor pagination. `depth == 0` is omitted from the query (API default = all levels).

## Why

incident.io wants customers to sync a **whole Confluence folder** as an AI document source, instead of adding pages one at a time (customer ask from cust-enfuce). Confluence's REST surface only exposes folder contents via the `folders/{id}/descendants` endpoint — the existing `Page` service (`GetsBySpace` / `GetsByParent`) can't enumerate a folder. This branch (`v1.6.1-fork`) is the one `core` consumes via its `go.mod` replace directive, so the addition lands here rather than `main`.

## Changes

| File | Change |
|---|---|
| `service/confluence/folder.go` | New `FolderConnector` interface |
| `confluence/internal/folder_impl.go` | `FolderService` + impl, mirrors `internalPageImpl.GetsByParent` |
| `pkg/infra/models/confluence_folder.go` | `FolderDescendantChunkScheme` / `FolderDescendantScheme` response models |
| `pkg/infra/models/errors.go` | `ErrNoFolderIDError` |
| `confluence/v2/api_client_impl.go` | Wire `client.Folder` into the v2 `Client` |
| `confluence/internal/folder_impl_test.go` | Table-driven tests (happy path, depth-omitted, missing id, request error, call error) |

## Testing

Written test-first. `go build ./...`, `go vet ./confluence/...`, and `go test ./confluence/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)