### PR TITLE
Add Confluence v2 Folder.Get

### DIFF
--- a/confluence/internal/folder_impl.go
+++ b/confluence/internal/folder_impl.go
@@ -20,6 +20,15 @@ type FolderService struct {
 	internalClient confluence.FolderConnector
 }
 
+// Get returns a specific folder.
+//
+// GET /wiki/api/v2/folders/{id}
+//
+// https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-folder/#api-folders-id-get
+func (f *FolderService) Get(ctx context.Context, folderID int) (*model.FolderScheme, *model.ResponseScheme, error) {
+	return f.internalClient.Get(ctx, folderID)
+}
+
 // Descendants returns all descendants of a folder, at any depth.
 //
 // Descendants are mixed content types (page, folder, whiteboard, database, embed).
@@ -37,6 +46,28 @@ func (f *FolderService) Descendants(ctx context.Context, folderID int, depth int
 
 type internalFolderImpl struct {
 	c service.Connector
+}
+
+func (i *internalFolderImpl) Get(ctx context.Context, folderID int) (*model.FolderScheme, *model.ResponseScheme, error) {
+
+	if folderID == 0 {
+		return nil, nil, model.ErrNoFolderIDError
+	}
+
+	endpoint := fmt.Sprintf("wiki/api/v2/folders/%v", folderID)
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	folder := new(model.FolderScheme)
+	response, err := i.c.Call(request, folder)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return folder, response, nil
 }
 
 func (i *internalFolderImpl) Descendants(ctx context.Context, folderID int, depth int, cursor string, limit int) (*model.FolderDescendantChunkScheme, *model.ResponseScheme, error) {

--- a/confluence/internal/folder_impl_test.go
+++ b/confluence/internal/folder_impl_test.go
@@ -12,6 +12,143 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_internalFolderImpl_Get(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx      context.Context
+		folderID int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:      context.Background(),
+				folderID: 20001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"wiki/api/v2/folders/20001",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.FolderScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the folder id is not provided",
+			args: args{
+				ctx: context.Background(),
+			},
+			wantErr: true,
+			Err:     model.ErrNoFolderIDError,
+		},
+
+		{
+			name: "when the http request cannot be created",
+			args: args{
+				ctx:      context.Background(),
+				folderID: 20001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"wiki/api/v2/folders/20001",
+					"", nil).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+
+		{
+			name: "when the call fails",
+			args: args{
+				ctx:      context.Background(),
+				folderID: 20001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"wiki/api/v2/folders/20001",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.FolderScheme{}).
+					Return(&model.ResponseScheme{}, errors.New("error, request failed"))
+
+				fields.c = client
+			},
+
+			wantErr: true,
+			Err:     errors.New("error, request failed"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			newService := NewFolderService(testCase.fields.c)
+
+			gotResult, gotResponse, err := newService.Get(testCase.args.ctx, testCase.args.folderID)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+
+		})
+	}
+}
+
 func Test_internalFolderImpl_Descendants(t *testing.T) {
 
 	type fields struct {

--- a/pkg/infra/models/confluence_folder.go
+++ b/pkg/infra/models/confluence_folder.go
@@ -1,5 +1,19 @@
 package models
 
+// FolderScheme represents a folder in Confluence.
+type FolderScheme struct {
+	ID         string `json:"id,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Title      string `json:"title,omitempty"`
+	ParentID   string `json:"parentId,omitempty"`
+	ParentType string `json:"parentType,omitempty"`
+	AuthorID   string `json:"authorId,omitempty"`
+	OwnerID    string `json:"ownerId,omitempty"`
+	CreatedAt  string `json:"createdAt,omitempty"`
+	SpaceID    string `json:"spaceId,omitempty"`
+}
+
 // FolderDescendantChunkScheme represents a chunk of folder descendants in Confluence.
 type FolderDescendantChunkScheme struct {
 	Results []*FolderDescendantScheme         `json:"results,omitempty"` // The descendants in the chunk.

--- a/service/confluence/folder.go
+++ b/service/confluence/folder.go
@@ -9,6 +9,13 @@ import (
 // Use it to navigate the contents of a folder.
 type FolderConnector interface {
 
+	// Get returns a specific folder.
+	//
+	// GET /wiki/api/v2/folders/{id}
+	//
+	// https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-folder/#api-folders-id-get
+	Get(ctx context.Context, folderID int) (*models.FolderScheme, *models.ResponseScheme, error)
+
 	// Descendants returns all descendants of a folder, at any depth.
 	//
 	// Descendants are mixed content types (page, folder, whiteboard, database, embed).


### PR DESCRIPTION
Adds `GET /wiki/api/v2/folders/{id}` — `Folder.Get(ctx, folderID)` returns a folder's metadata (`title`, `spaceId`, …).

Follow-up to #4 (`Folder.Descendants`). incident.io needs the title to label a folder when a customer adds one by URL as a document source.

- `service/confluence/folder.go` — `Get` on `FolderConnector`
- `confluence/internal/folder_impl.go` — `Get` impl
- `pkg/infra/models/confluence_folder.go` — `FolderScheme`
- table-driven tests (happy path, missing id, request error, call error)

`go build ./...`, `go vet`, `go test ./confluence/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)