### PR TITLE
Fix FolderScheme.CreatedAt type for v2 folder GET

### DIFF
--- a/pkg/infra/models/confluence_folder.go
+++ b/pkg/infra/models/confluence_folder.go
@@ -10,7 +10,7 @@ type FolderScheme struct {
 	ParentType string `json:"parentType,omitempty"`
 	AuthorID   string `json:"authorId,omitempty"`
 	OwnerID    string `json:"ownerId,omitempty"`
-	CreatedAt  string `json:"createdAt,omitempty"`
+	CreatedAt  int64  `json:"createdAt,omitempty"` // Epoch millis; v2 returns a number.
 	SpaceID    string `json:"spaceId,omitempty"`
 }
 


### PR DESCRIPTION
## What

`GET /wiki/api/v2/folders/{id}` returns the folder's top-level `createdAt` as a **numeric epoch (millis)**, e.g. `1781178911419` — not a string. `FolderScheme.CreatedAt` was typed `string`, so `Folder.Get` errored on a **200** with:

```
json: cannot unmarshal number into Go struct field FolderScheme.createdAt of type string
```

This surfaced in core as "couldn't find that Confluence folder" when a customer added a folder by URL — the underlying parse error was hidden behind a wrapped resolve error.

## Fix

Retype `CreatedAt string → int64` to match the wire format.

The nested `version.createdAt` *is* an ISO string — which is what the field was mistakenly modelled on. All other `FolderScheme` fields (`id`, `parentId`, `authorId`, `ownerId`, `spaceId`) are correctly strings; `position`/`version`/`_links` aren't modelled and are harmlessly ignored.

## Verification

Confirmed against a real folder: `Folder.Get` now returns `err=<nil>` and a fully-populated `FolderScheme` (`id`, `title`, `spaceId` all set) on the same 200 body that previously failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)